### PR TITLE
Improve setup script and docs for cross-platform use

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,17 @@ fileshazzer.py - Takes DJ sets (or any MP3) splitting them into shazamable segme
 
 seekspawner.py - Seeks and downloads the tracks on soulseek using slsk-batchdl command line tool. Soulseek login required.
 
+## Requirements
 
+- Python 3.11
+- [`ffmpeg`](https://ffmpeg.org/) command line tool
+- [.NET 6 SDK](https://dotnet.microsoft.com/en-us/download) (for building `slsk-batchdl`)
 
-# setup
+`setup.sh` attempts to install `ffmpeg` and the .NET SDK automatically on macOS and Debian/Ubuntu. If the script reports that .NET is still missing, install it manually and re-run `./setup.sh`.
 
-execute setup.sh from command line: 
+## setup
+
+execute setup.sh from command line:
 
 <code> chmod +x setup.sh </code> then <code> ./setup.sh </code>
 
@@ -20,9 +26,9 @@ execute setup.sh from command line:
 
 &nbsp; - creates the folders
 
-&nbsp; - there is prompt to enter your soulseek credentials so it can store them encrypted, so the main module can later use them to access soulseek
+&nbsp; - prompts for your soulseek credentials and stores them encrypted (set `SLSK_USERNAME` and `SLSK_PASSWORD` env vars to skip the prompt)
 
-&nbsp;&nbsp; this step is skippable and you can store them later or enter them every time. 
+&nbsp;&nbsp; this step is skippable and you can store them later or enter them every time.
 
 
 
@@ -31,9 +37,9 @@ execute setup.sh from command line:
 # run
 
 1. Put MP3s into 'sets' folder.<br>
-2. activate the virtual python environment with 
+2. activate the virtual python environment with
 
-&nbsp;&nbsp;  terminal: <code> source shaz_venv/bin/activate  </code>
+&nbsp;&nbsp;  terminal: <code> source setseek_venv/bin/activate  </code>
 
 
 <br>### to get track IDs and download them from soulseek, run all:
@@ -54,7 +60,7 @@ terminal: <code>python3.11 fileshazzer.py </code>
 &nbsp;&nbsp; - Default 30s go up if your tracklists get more than 4 instances of the same id / things are taking too long.
    
 
-<br>### you already have tracklist in the proper format and want to (re)attempt soulseek donwload
+<br>### you already have tracklist in the proper format and want to (re)attempt soulseek download
 
 terminal: <code>python3.11 seekspawner.py </code> 
 

--- a/setup.sh
+++ b/setup.sh
@@ -15,59 +15,87 @@ source setseek_venv/bin/activate
 pip install --upgrade pip
 pip install -r requirements.txt
 
-# 2. Install .NET 6 SDK if missing
+# 2. Ensure ffmpeg is available
+if ! command -v ffmpeg &> /dev/null; then
+    echo "ffmpeg not found. Attempting to install..."
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        brew install ffmpeg
+    elif command -v apt-get &> /dev/null; then
+        sudo apt-get update && sudo apt-get install -y ffmpeg
+    else
+        echo "Please install ffmpeg manually: https://ffmpeg.org/download.html"
+    fi
+else
+    echo "ffmpeg found"
+fi
+
+# 3. Setup default folders
+mkdir -p sets tracklists spoils user logs tmp/segments tmp/queries
+
+# 4. Install .NET 6 SDK if missing
+dotnet_missing=false
 if ! command -v dotnet &> /dev/null; then
-    echo ".NET 6 SDK not found. Installing..."
-    # macOS with Homebrew
+    echo ".NET 6 SDK not found. Attempting to install..."
     if [[ "$OSTYPE" == "darwin"* ]]; then
         brew install --cask dotnet-sdk
+    elif command -v apt-get &> /dev/null; then
+        wget https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+        sudo dpkg -i packages-microsoft-prod.deb
+        rm packages-microsoft-prod.deb
+        sudo apt-get update
+        sudo apt-get install -y dotnet-sdk-6.0
     else
         echo "Please install .NET 6 SDK manually: https://dotnet.microsoft.com/en-us/download"
-        exit 1
+    fi
+    if ! command -v dotnet &> /dev/null; then
+        echo ".NET 6 SDK still missing. Install it manually and re-run setup.sh."
+        dotnet_missing=true
     fi
 else
     echo ".NET SDK found"
 fi
 
-export DOTNET_ROOT=/usr/local/share/dotnet
-export PATH=$DOTNET_ROOT:$PATH
-echo "Setting up .NET environment variables DOTNET_ROOT and PATH..."
+if [ "$dotnet_missing" = false ]; then
+    export DOTNET_ROOT=/usr/local/share/dotnet
+    export PATH=$DOTNET_ROOT:$PATH
+    echo "Setting up .NET environment variables DOTNET_ROOT and PATH..."
 
-# 3. Clone slsk-batchdl if not present
-if [ ! -d "slsk-batchdl" ]; then
-    echo "Cloning slsk-batchdl..."
-    git clone https://github.com/fiso64/slsk-batchdl.git
+    # Clone slsk-batchdl if not present
+    if [ ! -d "slsk-batchdl" ]; then
+        echo "Cloning slsk-batchdl..."
+        git clone https://github.com/fiso64/slsk-batchdl.git
+    else
+        echo "slsk-batchdl already cloned."
+    fi
+
+    # Build slsk-batchdl
+    echo "🔨 Building slsk-batchdl..."
+    (cd slsk-batchdl/slsk-batchdl && dotnet build -c Release)
 else
-    echo "slsk-batchdl already cloned."
+    echo "Skipping slsk-batchdl build due to missing .NET."
 fi
 
-# 4. Build slsk-batchdl
-echo "🔨 Building slsk-batchdl..."
-cd slsk-batchdl/slsk-batchdl
-dotnet build -c Release
-cd ../..
-
-# 5. Setup default folders
-mkdir -p  sets tracklists spoils user logs tmp/segments tmp/queries
-
-# 6. Prompt to create Soulseek credentials file
+# 5. Prompt to create Soulseek credentials file
 
 if [ ! -f "user/slsk_cred.json" ]; then
-    echo "Enter Soulseek credentials now to be stored at user/slsk_cred.json"
-    echo "OR"
-    echo "Manually provide during each run of seekspawner."
-
-    read -p "Enter and store now? (Y/n) " answer
-    answer=${answer:-Y}  # default to 'Y' if empty
-
-    if [[ "$answer" =~ ^[Yy]$ ]]; then
-        read -p "Enter your Soulseek username: " username
-        read -s -p "Enter your Soulseek password: " password
-        echo ""
-        source setseek_venv/bin/activate
-        python3 crencrypt.py "$username" "$password" "user"
+    echo "Soulseek credentials are stored encrypted at user/slsk_cred.json"
+    echo "You can remove this file to reset them later."
+    if [[ -n "$SLSK_USERNAME" && -n "$SLSK_PASSWORD" ]]; then
+        python3 crencrypt.py "$SLSK_USERNAME" "$SLSK_PASSWORD" "user"
+        echo "Credentials stored from environment variables."
     else
-        echo "Ok Schwurbli, You'll be prompted to enter credentials every time when running seekspawner."
+        echo "Enter Soulseek credentials now to store them (or skip to provide at runtime)."
+        read -p "Enter and store now? (Y/n) " answer
+        answer=${answer:-Y}  # default to 'Y' if empty
+
+        if [[ "$answer" =~ ^[Yy]$ ]]; then
+            read -p "Enter your Soulseek username: " username
+            read -s -p "Enter your Soulseek password: " password
+            echo ""
+            python3 crencrypt.py "$username" "$password" "user"
+        else
+            echo "You'll be prompted to enter credentials every time when running seekspawner."
+        fi
     fi
 else
     echo "Soulseek credentials exist, change then? (Y/n)"
@@ -78,13 +106,15 @@ else
         read -p "Enter your Soulseek username: " username
         read -s -p "Enter your Soulseek password: " password
         echo ""
-        source setseek_venv/bin/activate
         python3 crencrypt.py "$username" "$password" "user"
     else
         echo "Keeping existing credentials."
     fi
 fi
 
+if [ "$dotnet_missing" = true ]; then
+    echo "⚠️  slsk-batchdl not built. Install .NET 6 SDK and re-run setup.sh."
+fi
 
 echo "setseek setup success"
 #echo "Always activate the virtual environment with:"


### PR DESCRIPTION
## Summary
- Attempt automatic ffmpeg and .NET 6 installation on macOS and apt-based Linux
- Skip slsk-batchdl build when .NET isn't available and instruct to re-run setup
- Allow Soulseek credentials via environment variables and document requirements

## Testing
- `bash -n setup.sh`
- `python -m py_compile fileshazzer.py seekspawner.py crencrypt.py`


------
https://chatgpt.com/codex/tasks/task_e_689c9c9864d8832dadee22979a50f193